### PR TITLE
グローバルナビのスマホサイズ時、子メニューが開かないようにcss設定。

### DIFF
--- a/div/css/main.css
+++ b/div/css/main.css
@@ -283,11 +283,11 @@ p {
     #nav li #s4:target + ul.subs,
     #nav li #s5:target + ul.subs,
     #nav li #s6:target + ul.subs, {
-        display: block;
+        display: none;
     }
 
     #nav ul.subs > li {
-        display: block;
+        display: none;
         width: auto;
     }
 


### PR DESCRIPTION
グローバルナビのスマホサイズ時、子メニューが開かないようにcss設定。
